### PR TITLE
feat: display available doctor and available time on home page

### DIFF
--- a/content/doctors/dr-sharma.md
+++ b/content/doctors/dr-sharma.md
@@ -1,9 +1,10 @@
 ---
+title: "Dr. Ramesh Sharma"
 id: d1
 name: "Dr. Ramesh Sharma"
 speciality: "Cardiologist"
 bookings:
-  2025-09-05:
-    - time: "09:00 AM"
-  2025-09-06: []
+  "2025-09-09":
+    - "09:00 AM"
+    - "11:30 AM"
 ---

--- a/content/index.md
+++ b/content/index.md
@@ -1,3 +1,4 @@
 ---
-title: Book Doctor Appointment
+title: "Book Doctor Appointment"
 ---
+Welcome to the doctor appointment booking system.

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -8,6 +8,7 @@
    <h1>{{ .Title }}</h1> 
     <div>
         {{ .Content }} 
+        {{ partial "available-doctors.html" . }}
     </div>
 </body>
 </html>

--- a/layouts/partials/available-doctors.html
+++ b/layouts/partials/available-doctors.html
@@ -1,0 +1,22 @@
+<h2>Available Doctors and Slots</h2>
+{{ $today := now.Format "2006-01-02" }}
+{{ $slots := slice "09:00 AM" "09:30 AM" "10:00 AM" "10:30 AM" "11:00 AM" "11:30 AM" "12:00 PM" "12:30 PM" "01:00 PM" "01:30 PM" "02:00 PM" "02:30 PM" "03:00 PM" "03:30 PM" "04:00 PM" "04:30 PM" "05:00 PM" }}
+{{ $doctors := where .Site.RegularPages "Section" "doctors" }}
+{{ if gt (len $doctors) 0 }}
+  {{ range $doctors }}
+    <div style="border:1px solid #ccc; padding:10px; margin-bottom:15px;">
+      <h3>{{ .Params.name }} ({{ .Params.speciality }})</h3>
+      <strong>Available Slots Today ({{ $today }}):</strong>
+      <ul>
+        {{ $booked := index .Params.bookings $today | default (slice) }}
+        {{ range $slot := $slots }}
+          {{ if not (in $booked $slot) }}
+            <li>{{ $slot }} <button>Book</button></li>
+          {{ end }}
+        {{ end }}
+      </ul>
+    </div>
+  {{ end }}
+{{ else }}
+  <p>No doctors found</p>
+{{ end }}


### PR DESCRIPTION
## What
- Added dynamic display of available doctors and their time slots on the home page.
- Enhanced frontmatter of doctor data to include correct booking date and time.
- Corrected date in frontmatter to reflect today’s date for accurate slot display.

## How
- Created a new partial template "available-doctors.html" that dynamically lists doctors and available slots.
- Used Hugo's template functions to filter booked slots and display only available ones.
- Updated the index page to call this partial.
- Fixed frontmatter in doctor markdown files for correct date structure.

## Why
- To allow users to view and book available doctor slots in real-time.
- Improve user experience by showing only valid, unbooked time slots.
- Fix incorrect date in frontmatter that previously showed wrong availability.

## Previous
- No dynamic display of available doctors and slots.
- Doctor frontmatter had outdated or incorrect booking dates.

## Now
- Home page shows real-time list of doctors and available time slots based on today’s date.
- User can view available slots and interact with the system more effectively.
